### PR TITLE
Slår samemn utbetalingslinjer til ett Vedtak

### DIFF
--- a/src/main/kotlin/no/nav/helse/Rivers.kt
+++ b/src/main/kotlin/no/nav/helse/Rivers.kt
@@ -122,8 +122,8 @@ class UtbetaltRiverV3(
                     val utbetalingslinjer = utbetaling["utbetalingslinjer"]
                     val forbrukteStønadsdager =
                         utbetalingslinjer.fold(0) { acc, jsonNode -> acc + jsonNode["sykedager"].intValue() }
-                    val fom = utbetalingslinjer.map { it["fom"].asLocalDate() }.min()!!
-                    val tom = utbetalingslinjer.map { it["tom"].asLocalDate() }.max()!!
+                    val fom = requireNotNull(utbetalingslinjer.map { it["fom"].asLocalDate() }.min())
+                    val tom = requireNotNull(utbetalingslinjer.map { it["tom"].asLocalDate() }.max())
                     Vedtak(
                         type = Vedtak.Vedtakstype.SykepengerUtbetalt_v1,
                         opprettet = packet["opprettet"].asLocalDateTime(),


### PR DESCRIPTION
Tidligere ble det publisert et vedtak pr linje i utbetalinger, og disse
fikk samme fagsystemId. Dette gjorde at kun en av dem ble vist i
GE VL-skjermbildet i Infotrygd.